### PR TITLE
Settings: fix profile triggers not showing up for RTL languages

### DIFF
--- a/res/layout/abstract_trigger_row.xml
+++ b/res/layout/abstract_trigger_row.xml
@@ -39,7 +39,7 @@
 
         android:layout_alignParentBottom="true"
         android:layout_alignParentRight="true"
-        android:layout_toRightOf="@id/icon"
+        android:layout_toEndOf="@id/icon"
 
         android:ellipsize="marquee"
         android:singleLine="true"/>
@@ -54,7 +54,7 @@
         android:layout_alignParentRight="true"
         android:layout_alignParentTop="true"
         android:layout_alignWithParentIfMissing="true"
-        android:layout_toRightOf="@id/icon"
+        android:layout_toEndOf="@id/icon"
 
         android:gravity="center_vertical"
         android:textStyle="bold" />


### PR DESCRIPTION
The layout was placing the title and summary off the screen for RTL
layouts.

Change-Id: I30e560fb9565581b2f55a826e90e110383581f28
Signed-off-by: Roman Birg roman@cyngn.com
